### PR TITLE
feat: 하드코딩된 ID 카카로그인으로 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+
+application.yml

--- a/src/main/kotlin/com/pleasybank/account/controller/AccountController.kt
+++ b/src/main/kotlin/com/pleasybank/account/controller/AccountController.kt
@@ -4,6 +4,7 @@ import com.pleasybank.account.dto.*
 import com.pleasybank.account.service.AccountService
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.web.bind.annotation.*
 
 @RestController
@@ -13,44 +14,42 @@ class AccountController(
 ) {
 
     @GetMapping
-    fun getAccounts(@AuthenticationPrincipal userId: Long): ResponseEntity<AccountListResponse> {
-        // 인증된 사용자의 ID를 가져오는 방식에 따라 다를 수 있음
-        // 여기서는 임시로 userId를 직접 받는 형태로 작성
-        val userId = 1L // 테스트용 임시 사용자 ID, 실제로는 @AuthenticationPrincipal에서 가져옴
+    fun getAccounts(@AuthenticationPrincipal userDetails: UserDetails): ResponseEntity<AccountListResponse> {
+        val userId = userDetails.username.toLong()
         val response = accountService.getAccountsList(userId)
         return ResponseEntity.ok(response)
     }
 
     @GetMapping("/{accountId}")
     fun getAccountDetail(
-        @AuthenticationPrincipal userId: Long,
+        @AuthenticationPrincipal userDetails: UserDetails,
         @PathVariable accountId: Long
     ): ResponseEntity<AccountDetailResponse> {
-        val userId = 1L // 테스트용 임시 사용자 ID, 실제로는 @AuthenticationPrincipal에서 가져옴
+        val userId = userDetails.username.toLong()
         val response = accountService.getAccountDetail(userId, accountId)
         return ResponseEntity.ok(response)
     }
 
     @GetMapping("/{accountId}/balance")
     fun getAccountBalance(
-        @AuthenticationPrincipal userId: Long,
+        @AuthenticationPrincipal userDetails: UserDetails,
         @PathVariable accountId: Long
     ): ResponseEntity<AccountBalanceResponse> {
-        val userId = 1L // 테스트용 임시 사용자 ID, 실제로는 @AuthenticationPrincipal에서 가져옴
+        val userId = userDetails.username.toLong()
         val response = accountService.getAccountBalance(userId, accountId)
         return ResponseEntity.ok(response)
     }
 
     @GetMapping("/{accountId}/transactions")
     fun getAccountTransactions(
-        @AuthenticationPrincipal userId: Long,
+        @AuthenticationPrincipal userDetails: UserDetails,
         @PathVariable accountId: Long,
         @RequestParam(required = false) startDate: String?,
         @RequestParam(required = false) endDate: String?,
         @RequestParam(defaultValue = "0") page: Int,
         @RequestParam(defaultValue = "20") size: Int
     ): ResponseEntity<AccountTransactionListResponse> {
-        val userId = 1L // 테스트용 임시 사용자 ID, 실제로는 @AuthenticationPrincipal에서 가져옴
+        val userId = userDetails.username.toLong()
         
         val request = AccountTransactionListRequest(
             startDate = startDate,

--- a/src/main/kotlin/com/pleasybank/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/pleasybank/security/config/SecurityConfig.kt
@@ -1,0 +1,69 @@
+package com.pleasybank.security.config
+
+import com.pleasybank.security.jwt.JwtAuthenticationFilter
+import com.pleasybank.security.jwt.JwtTokenProvider
+import com.pleasybank.security.oauth2.CustomOAuth2UserService
+import com.pleasybank.security.oauth2.OAuth2AuthenticationSuccessHandler
+import com.pleasybank.security.oauth2.OAuth2AuthenticationFailureHandler
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+
+@Configuration
+@EnableWebSecurity
+class SecurityConfig(
+    private val jwtTokenProvider: JwtTokenProvider,
+    private val customOAuth2UserService: CustomOAuth2UserService,
+    private val oAuth2AuthenticationSuccessHandler: OAuth2AuthenticationSuccessHandler,
+    private val oAuth2AuthenticationFailureHandler: OAuth2AuthenticationFailureHandler
+) {
+    
+    @Bean
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http
+            .cors().and()
+            .csrf().disable()
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .authorizeHttpRequests { auth -> 
+                auth
+                    .requestMatchers("/api/auth/**").permitAll()
+                    .requestMatchers("/h2-console/**").permitAll()
+                    .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                    .anyRequest().authenticated()
+            }
+            .oauth2Login { oauth2 ->
+                oauth2
+                    .authorizationEndpoint { endpoint ->
+                        endpoint.baseUri("/api/auth/oauth2/authorize")
+                    }
+                    .redirectionEndpoint { endpoint ->
+                        endpoint.baseUri("/api/auth/oauth2/callback/*")
+                    }
+                    .userInfoEndpoint { endpoint ->
+                        endpoint.userService(customOAuth2UserService)
+                    }
+                    .successHandler(oAuth2AuthenticationSuccessHandler)
+                    .failureHandler(oAuth2AuthenticationFailureHandler)
+            }
+            .addFilterBefore(JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter::class.java)
+            
+        // H2 콘솔을 위한 설정
+        http
+            .headers { headers ->
+                headers.frameOptions().disable()
+            }
+            
+        return http.build()
+    }
+    
+    @Bean
+    fun passwordEncoder(): PasswordEncoder {
+        return BCryptPasswordEncoder()
+    }
+} 

--- a/src/main/kotlin/com/pleasybank/security/jwt/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/pleasybank/security/jwt/JwtAuthenticationFilter.kt
@@ -3,7 +3,10 @@ package com.pleasybank.security.jwt
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.core.userdetails.UserDetails
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource
 import org.springframework.web.filter.OncePerRequestFilter
 
 class JwtAuthenticationFilter(
@@ -15,23 +18,46 @@ class JwtAuthenticationFilter(
         response: HttpServletResponse,
         filterChain: FilterChain
     ) {
-        val token = getTokenFromRequest(request)
-        
-        if (token != null && jwtTokenProvider.validateToken(token)) {
-            val authentication = jwtTokenProvider.getAuthentication(token)
-            SecurityContextHolder.getContext().authentication = authentication
+        try {
+            val jwt = getJwtFromRequest(request)
+            if (jwt != null && jwtTokenProvider.validateToken(jwt)) {
+                val userId = jwtTokenProvider.getUserIdFromToken(jwt)
+                val userDetails = createUserDetails(userId)
+                
+                val authentication = UsernamePasswordAuthenticationToken(
+                    userDetails, null, userDetails.authorities
+                )
+                authentication.details = WebAuthenticationDetailsSource().buildDetails(request)
+                SecurityContextHolder.getContext().authentication = authentication
+            }
+        } catch (ex: Exception) {
+            logger.error("JWT 인증에 실패했습니다: ${ex.message}")
         }
         
         filterChain.doFilter(request, response)
     }
     
-    private fun getTokenFromRequest(request: HttpServletRequest): String? {
+    private fun getJwtFromRequest(request: HttpServletRequest): String? {
         val bearerToken = request.getHeader("Authorization")
         
         return if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
             bearerToken.substring(7)
         } else {
             null
+        }
+    }
+    
+    private fun createUserDetails(userId: String): UserDetails {
+        // 실제 애플리케이션에서는 userId로 사용자 정보를 조회하여 UserDetails 객체를 생성해야 합니다.
+        // 여기서는 간단한 예시로 userId만 담은 UserDetails 객체를 생성합니다.
+        return object : UserDetails {
+            override fun getAuthorities() = listOf(org.springframework.security.core.authority.SimpleGrantedAuthority("ROLE_USER"))
+            override fun getPassword() = null
+            override fun getUsername() = userId
+            override fun isAccountNonExpired() = true
+            override fun isAccountNonLocked() = true
+            override fun isCredentialsNonExpired() = true
+            override fun isEnabled() = true
         }
     }
 } 

--- a/src/main/kotlin/com/pleasybank/security/oauth2/OAuth2AuthenticationFailureHandler.kt
+++ b/src/main/kotlin/com/pleasybank/security/oauth2/OAuth2AuthenticationFailureHandler.kt
@@ -1,0 +1,29 @@
+package com.pleasybank.security.oauth2
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler
+import org.springframework.stereotype.Component
+import org.springframework.web.util.UriComponentsBuilder
+
+@Component
+class OAuth2AuthenticationFailureHandler(
+    @Value("\${app.oauth2.authorized-redirect-uris[0]}") private val defaultRedirectUri: String
+) : SimpleUrlAuthenticationFailureHandler() {
+
+    override fun onAuthenticationFailure(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        exception: AuthenticationException
+    ) {
+        val redirectUri = request.getParameter("redirect_uri") ?: defaultRedirectUri
+        
+        val targetUrl = UriComponentsBuilder.fromUriString(redirectUri)
+            .queryParam("error", exception.localizedMessage)
+            .build().toUriString()
+
+        redirectStrategy.sendRedirect(request, response, targetUrl)
+    }
+} 

--- a/src/main/kotlin/com/pleasybank/security/oauth2/OAuth2AuthenticationSuccessHandler.kt
+++ b/src/main/kotlin/com/pleasybank/security/oauth2/OAuth2AuthenticationSuccessHandler.kt
@@ -1,0 +1,68 @@
+package com.pleasybank.security.oauth2
+
+import com.pleasybank.security.jwt.JwtTokenProvider
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.core.Authentication
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler
+import org.springframework.stereotype.Component
+import org.springframework.web.util.UriComponentsBuilder
+import java.net.URI
+
+@Component
+class OAuth2AuthenticationSuccessHandler(
+    private val jwtTokenProvider: JwtTokenProvider,
+    @Value("\${app.oauth2.authorized-redirect-uris}") private val authorizedRedirectUris: List<String>
+) : SimpleUrlAuthenticationSuccessHandler() {
+
+    override fun onAuthenticationSuccess(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authentication: Authentication
+    ) {
+        val redirectUri = getRedirectUri(request)
+        if (!isAuthorizedRedirectUri(redirectUri)) {
+            throw IllegalArgumentException("인증 리다이렉트 URI가 승인되지 않았습니다.")
+        }
+
+        val oAuth2User = authentication.principal as DefaultOAuth2UserImpl
+        val userId = oAuth2User.getId()
+        val accessToken = jwtTokenProvider.createToken(userId.toString(), "ROLE_USER")
+        val refreshToken = jwtTokenProvider.createRefreshToken(userId.toString())
+        
+        val targetUrl = UriComponentsBuilder.fromUriString(redirectUri)
+            .queryParam("token", accessToken)
+            .queryParam("refreshToken", refreshToken)
+            .build().toUriString()
+
+        clearAuthenticationAttributes(request, response)
+        redirectStrategy.sendRedirect(request, response, targetUrl)
+    }
+
+    private fun getRedirectUri(request: HttpServletRequest): String {
+        val redirectUri = request.getParameter("redirect_uri")
+        return redirectUri ?: defaultTargetUrl
+    }
+
+    private fun isAuthorizedRedirectUri(uri: String): Boolean {
+        val clientRedirectUri = URI.create(uri)
+        return authorizedRedirectUris
+            .map { URI.create(it) }
+            .any { authorizedUri ->
+                authorizedUri.host.equals(clientRedirectUri.host, ignoreCase = true) &&
+                authorizedUri.port == clientRedirectUri.port
+            }
+    }
+
+    private fun clearAuthenticationAttributes(request: HttpServletRequest, response: HttpServletResponse) {
+        super.clearAuthenticationAttributes(request)
+    }
+}
+
+// OAuth2User 구현체 클래스 (토큰 생성을 위한 ID 추출 용도)
+class DefaultOAuth2UserImpl(private val attributes: Map<String, Any>) {
+    fun getId(): Long {
+        return attributes["id"] as Long
+    }
+} 

--- a/src/main/kotlin/com/pleasybank/security/oauth2/OAuth2UserInfo.kt
+++ b/src/main/kotlin/com/pleasybank/security/oauth2/OAuth2UserInfo.kt
@@ -1,0 +1,41 @@
+package com.pleasybank.security.oauth2
+
+abstract class OAuth2UserInfo(
+    val attributes: Map<String, Any>
+) {
+    abstract fun getId(): String
+    abstract fun getName(): String?
+    abstract fun getEmail(): String?
+    abstract fun getImageUrl(): String?
+}
+
+class KakaoOAuth2UserInfo(attributes: Map<String, Any>) : OAuth2UserInfo(attributes) {
+    override fun getId(): String {
+        return attributes["id"].toString()
+    }
+
+    override fun getName(): String? {
+        val properties = attributes["properties"] as? Map<String, Any>
+        return properties?.get("nickname") as? String
+    }
+
+    override fun getEmail(): String? {
+        val kakaoAccount = attributes["kakao_account"] as? Map<String, Any>
+        return kakaoAccount?.get("email") as? String
+    }
+
+    override fun getImageUrl(): String? {
+        val properties = attributes["properties"] as? Map<String, Any>
+        return properties?.get("profile_image") as? String
+    }
+}
+
+object OAuth2UserInfoFactory {
+    fun getOAuth2UserInfo(registrationId: String, attributes: Map<String, Any>): OAuth2UserInfo {
+        return when (registrationId.toLowerCase()) {
+            "kakao" -> KakaoOAuth2UserInfo(attributes)
+            // 여기에 다른 OAuth2 제공자(Google, Naver 등)에 대한 구현을 추가할 수 있습니다.
+            else -> throw IllegalArgumentException("지원되지 않는 로그인 제공자입니다: $registrationId")
+        }
+    }
+} 

--- a/src/main/kotlin/com/pleasybank/user/entity/User.kt
+++ b/src/main/kotlin/com/pleasybank/user/entity/User.kt
@@ -16,47 +16,33 @@ data class User(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
     
-    @Column(nullable = false, unique = true)
+    @Column(unique = true, nullable = false)
     val email: String,
     
     @Column(nullable = false)
-    val password: String,
+    var password: String,
     
     @Column(nullable = false)
-    val name: String,
+    var name: String,
     
-    @Column(nullable = false, name = "phone_number")
-    val phoneNumber: String,
+    var phoneNumber: String? = null,
     
-    @Column(name = "birth_date")
-    val birthDate: LocalDate? = null,
+    // OAuth2 관련 필드
+    var provider: String? = null,
     
-    val address: String? = null,
+    var providerId: String? = null,
     
-    @Column(nullable = false, name = "created_at")
-    val createdAt: LocalDateTime = LocalDateTime.now(),
+    var profileImage: String? = null,
     
-    @Column(nullable = false, name = "updated_at")
-    var updatedAt: LocalDateTime = LocalDateTime.now(),
+    // 계정 상태 및 시간 관련 필드
+    @Column(nullable = false)
+    var status: String, // ACTIVE, INACTIVE, LOCKED
     
-    @Column(name = "last_login_at")
     var lastLoginAt: LocalDateTime? = null,
     
     @Column(nullable = false)
-    var status: String = "ACTIVE",
+    val createdAt: LocalDateTime,
     
-    @OneToMany(mappedBy = "user", cascade = [CascadeType.ALL], orphanRemoval = true)
-    val authentications: MutableList<UserAuthentication> = mutableListOf(),
-    
-    @OneToMany(mappedBy = "user", cascade = [CascadeType.ALL], orphanRemoval = true)
-    val oauthConnections: MutableList<UserOAuth> = mutableListOf(),
-    
-    @OneToMany(mappedBy = "user", cascade = [CascadeType.ALL], orphanRemoval = true)
-    val passwordResets: MutableList<PasswordReset> = mutableListOf(),
-    
-    @OneToMany(mappedBy = "user", cascade = [CascadeType.ALL], orphanRemoval = true)
-    val accounts: MutableList<Account> = mutableListOf(),
-    
-    @OneToMany(mappedBy = "user", cascade = [CascadeType.ALL], orphanRemoval = true)
-    val notifications: MutableList<Notification> = mutableListOf()
+    @Column(nullable = false)
+    var updatedAt: LocalDateTime
 ) 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,18 +1,40 @@
-# 데이터베이스 설정
-spring.datasource.url=jdbc:h2:mem:pleasybank
-spring.datasource.username=sa
-spring.datasource.password=
-spring.datasource.driver-class-name=org.h2.Driver
-
-# JPA 설정
-spring.jpa.hibernate.ddl-auto=update
-spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.format_sql=true
-spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
-
-# H2 콘솔 설정 (개발 환경용)
-spring.h2.console.enabled=true
-spring.h2.console.path=/h2-console
+spring:
+  datasource:
+    url: jdbc:h2:mem:pleasybank
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+    show-sql: true
+  h2:
+    console:
+      enabled: true
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID:your-client-id}
+            client-secret: ${KAKAO_CLIENT_SECRET:your-client-secret}
+            redirect-uri: "{baseUrl}/api/auth/oauth2/callback/kakao"
+            authorization-grant-type: authorization_code
+            client-authentication-method: POST
+            client-name: Kakao
+            scope:
+              - profile_nickname
+              - profile_image
+              - account_email
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
 
 # 로깅 설정
 logging.level.org.hibernate.SQL=DEBUG
@@ -27,20 +49,11 @@ jwt.secret=pleasyBankSecretKey12345678901234567890123456789012345678901234567890
 jwt.expiration=86400000
 jwt.refresh-expiration=604800000
 
-# OAuth2 설정
-spring.security.oauth2.client.registration.kakao.client-id=${KAKAO_CLIENT_ID:kakao-client-id}
-spring.security.oauth2.client.registration.kakao.client-secret=${KAKAO_CLIENT_SECRET:kakao-client-secret}
-spring.security.oauth2.client.registration.kakao.redirect-uri={baseUrl}/api/auth/oauth2/callback/{registrationId}
-spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code
-spring.security.oauth2.client.registration.kakao.scope=profile_nickname,account_email
-spring.security.oauth2.client.registration.kakao.client-name=Kakao
-spring.security.oauth2.client.registration.kakao.client-authentication-method=client_secret_post
-
-# OAuth2 프로바이더 설정
-spring.security.oauth2.client.provider.kakao.authorization-uri=https://kauth.kakao.com/oauth/authorize
-spring.security.oauth2.client.provider.kakao.token-uri=https://kauth.kakao.com/oauth/token
-spring.security.oauth2.client.provider.kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
-spring.security.oauth2.client.provider.kakao.user-name-attribute=id
-
-# OAuth2 리다이렉트 URI (프론트엔드 주소로 설정)
-oauth2.redirect-uri=http://localhost:3000/oauth/callback 
+app:
+  auth:
+    token-secret: ${JWT_SECRET:pleasyBankSecretKey012345678901234567890123456789}
+    token-expiration-ms: 3600000  # 1 hour
+    refresh-token-expiration-ms: 2592000000  # 30 days
+  oauth2:
+    authorized-redirect-uris:
+      - http://localhost:3000/oauth2/redirect


### PR DESCRIPTION
Close #5 
기존에 있던 하드코딩 된 사용자 ID를 카카오 OAuth2 로그인으로 대체
---
1. **OAuth2 설정 추가**:
   - application.yml에 카카오 OAuth2 설정 추가
   - 인증 리다이렉트 URI 및 토큰 시크릿 설정

2. **OAuth2 관련 클래스 생성**:
   - `CustomOAuth2UserService`: 카카오 로그인 후 사용자 정보 처리
   - `OAuth2UserInfo` 및 `KakaoOAuth2UserInfo`: 카카오 API 응답 데이터 매핑
   - `OAuth2AuthenticationSuccessHandler`: 인증 성공 시 JWT 토큰 발급
   - `OAuth2AuthenticationFailureHandler`: 인증 실패 시 처리

3. **JWT 인증 로직 개선**:
   - `JwtTokenProvider`: 토큰 생성 및 검증 로직 개선
   - `JwtAuthenticationFilter`: 요청에서 토큰 추출 및 인증 처리

4. **사용자 엔티티 확장**:
   - `User` 클래스에 OAuth2 관련 필드 추가 (provider, providerId, profileImage)

5. **컨트롤러 수정**:
   - 하드코딩된 사용자 ID(1L) 대신 `@AuthenticationPrincipal`에서 현재 인증된 사용자 정보 사용
   - JWT 토큰에서 추출한 사용자 ID를 서비스 호출에 사용

이제 카카오 로그인을 통해 인증할 수 있으며, 로그인 후에는 JWT 토큰을 사용하여 보안 API에 접근할 수 있습니다. 

로그인 과정은 다음과 같이 진행됩니다.

1. 사용자가 `/api/auth/oauth2/authorize/kakao`로 리다이렉트됨
2. 카카오 로그인 페이지에서 인증 완료
3. 인증 성공 시 지정된 리다이렉트 URI로 JWT 토큰과 함께 이동
4. 이후 API 요청 시 JWT 토큰을 Authorization 헤더에 포함하여 전송

각 API 컨트롤러는 하드코딩된 사용자 ID 대신 인증된 사용자의 실제 ID를 사용하므로, 모든 사용자가 자신의 정보에만 접근할 수 있게 됩니다.
